### PR TITLE
Change text surrounding form

### DIFF
--- a/contributor/index.html
+++ b/contributor/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="../stylesheets/stylesheet.css" media="screen" />
-    <title>Ecma International, TC39 ECMAScript Software Contribution Form</title>
+    <title>Ecma International, TC39 ECMAScript RFTG Contributor Form</title>
   </head>
 
   <body>
@@ -14,40 +14,14 @@
         <section id="main_content">
         <img src="../images/ecma.jpg">
           <h3>Ecma International, TC39 ECMAScript RFTG Contributor Form</h3>
-<p>This is a simplified, online version of the Ecma International, TC39 <a href="http://www.ecma-international.org/memento/TC39%20exhibit%20B.pdf">Software Submitter Contribution Form</a> and associated <a href="http://www.ecma-international.org/memento/TC39%20experimental%20policy.htm">policies</a> for use for contributions to the standards ECMA-262 and ECMA-402 and for possible future ECMAScript standards.</p>
-<h4>I. Contributor Information</h4>
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeoTONO6trKLhO4nacVOgVKib75vhSPJGbgVwyG4Bu4J__yWw/viewform?embedded=true" width="760" height="2200" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
-<h4>II. Representations and Warranties; Disclaimer of Other Warranties; Grant of Copyright License</h4>
-<ol>
-<li>Software Submitter represents and warrants at the time of this submission by it that, (i) if Software Submitter is making the submission on behalf of an entity, (A) such entity has authorized the submission, and (B) the Software Submitter signing this agreement is hereby authorized to make Software submissions on behalf of the legal entity, (ii) to the reasonable knowledge of the employee or individual actually making the submission, the submission is subject to the terms of Ecma International Policy on Inclusion of Software in Standards and Technical Reports (the ”Policy”) [available at http://www.ecma-international.org/memento/TC39%20experimental%20policy.htm] and does not violate the copyright or trade secret interests of another, and (iii) nothing in the submission is subject to any third party software license agreement that is inconsistent with the Policy or that could impose an additional obligation on any party using the Software as contemplated by Ecma International (such as, without limitation, an open source license with on-going obligations to distribute source code or to license additional intellectual property rights on a royalty-free basis if the software is redistributed).</li>
-<li>SOFTWARE SUBMITTER DISCLAIMS ALL WARRANTIES (EXCEPT THOSE SET FORTH IN SECTION II. A ABOVE), EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, (I) ANY WARRANTY OF TITLE OR THAT THE SUBMISSION DOES NOT INFRINGE THE INTELLECUTAL PROPERTY RIGHTS OF ANY OTHER PERSON OR ENTITY, (II) ANY IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, AND (III) THAT THE RIGHTS AND LICENSES GRANTED HEREUNDER COMPRISE ALL THE RIGHTS AND LICENSES NECESSARY OR DESIRABLE TO PRACTICE DEVELOP, MAKE OR SELL PRODUCTS WHICH IMPLEMENT THE SOFTWARE.</li>
-<li>Software Submitter either (choose one):
-  <ol style="padding-left: 2em;">
-    <li>☑ hereby grants a license to the Software pursuant to the BSD License set forth below.</li>
-    <li>☐ hereby grants to Ecma International and its members, an irrevocable, worldwide perpetual, royalty free, nontransferable, non-exclusive license under its copyrights in its software submission to modify such software submission and reproduce the modified or unmodified software submission for the sole purpose of developing an Ecma standard . Requires submission of PDF form linked above.</li>
-  </ol>
-</li>
-<li>Software Submitter hereby grants to Ecma International, a worldwide, irrevocable, nontransferable royalty free copyright license to reproduce, create derivative works, distribute, display, perform and sublicense the rights to reproduce, make derivative works of , distribute, display and perform its copyright interest in its Software submission or portions thereof incorporated into final Ecma International Standards. </li>
-<li>Software Submitter acknowledges that, while Software Submitter continues to own the copyright in the Software that it submits, Ecma International owns, and has the right to enforce, the copyright in the collective work (e.g., the Ecma International Standard that incorporates all text and Software contributions). </li>
-<li>Software Submitter acknowledges the applicability of and agrees to abide by the terms of the Ecma Code of Conduct in Patent Matters with respect to patents that are required to implement the subject final Ecma International Standard.<br>
-</li>
-<li> Except as expressly set forth herein, the Software Submitter reserves for itself all other intellectual property rights in its Software submission and makes no assignment, license or other transfer or any other intellectual property rights.<br>
-</li>
-</ol>
-        </section>
-      
-        
-        <h4>Attachment 1: BSD License</h4>
-        <p>Replace YEAR and OWNER with appropriate values.</p>
-        <pre style="white-space:pre-wrap;">
-Copyright (c) &lt; YEAR &gt;, &lt; OWNER &gt; All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
-        </pre>
+<p>This form is used to grant a license to intellectual property rights related to contributions to ECMAScript standards ECMA-262 and ECMA-402, developed in the Ecma TC39 Royalty-Free Task Group. It is required in the following cases:</p>
+<ul>
+  <li>To attend a TC39 meeting as an invited expert and participate in committee discussion</li>
+  <li>To contribute a normative change to an ECMA-262, ECMA-402 or a proposal repository under the tc39 organization</li>
+</ul>
+<p>This form does not grant the right to attend TC39 meetings; see <a href="http://www.ecma-international.org/memento/join.htm">the Ecma website</a> for more information on joining Ecma.</p>
+<p>When a non-member contributor works within an organization where they do not have the authorization to license their contributed IPR, the form can be filled out with separate "signatory" and "contributor" fields, where the "contributor" is the participant in TC39 work, and the "signatory" is the member of the organization who is authorized to license the IPR. The form must be signed for each individual contributor who participates in TC39, and does not apply organization-wide.</p>
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeoTONO6trKLhO4nacVOgVKib75vhSPJGbgVwyG4Bu4J__yWw/viewform?embedded=true" width="760" height="3000" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
       </div>
     </div>
   </body>


### PR DESCRIPTION
- Removes copies of certain licenses that come after the form
  (the relevant license is linked to from the contract text)
- Replace text which precedes the form with an actual explanation
  of what the form is for.